### PR TITLE
Ignore cross compiler built archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ conf/setup.conf
 #	Binaries
 #
 *.o
+*.a
 
 #
 #	Built cross compiler binaries


### PR DESCRIPTION
`gcc` generates archives which get spotted by git.

This .gitignore rule may be too heavy handed although it is (probably) never desired that binary archive files are checked into source control. 