### PR TITLE
Riscv build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ cross-superH:
 
 cross-riscv:
 	cd $(TOOLS); $(MAKE) PATH=$(Z)\
-	TARGET=riscv TARGET-ARCH=riscv32-elf ADDITIONAL_ARCH_FLAGS="--with-arch=rv32ifd" all;\
+	TARGET=riscv TARGET-ARCH=riscv32-elf all;\
 
 cross-all:
 	cd $(TOOLS); $(MAKE) PATH=$(Z)\

--- a/conf/setup.conf
+++ b/conf/setup.conf
@@ -17,7 +17,7 @@ GMAKE		= /usr/bin/make
 #
 #       Specifies the architecture used. Uncomment for riscv builds.
 #
-#ADDITIONAL_ARCH_FLAGS = --with-cpu=rv32ifd
+#ADDITIONAL_ARCH_FLAGS = --with-arch=rv32ifd
 
 #
 #	On newer versions of macOS (High Sierra), you will need to install gcc


### PR DESCRIPTION
Removed additional arch flags so that they can be inherited from conf/setup.conf.

Also changed the commented RV32 ARCH_FLAGS to a valid flag (--with-cpu is not a flag for rv32)