### PR TITLE
Issue #20, duplication in Makefiles removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,11 @@ cross-riscv:
 	cd $(TOOLS); $(MAKE) PATH=$(Z)\
 	TARGET=riscv TARGET-ARCH=riscv32-elf ADDITIONAL_ARCH_FLAGS="--with-arch=rv32ifd" all;\
 
-cross-all:
-	cd $(TOOLS); $(MAKE) PATH=$(Z)\
-	TARGET=superH TARGET-ARCH=sh-elf ADDITIONAL_ARCH_FLAGS="--disable-multilib" all;\
-	cd $(TOOLS); $(MAKE) PATH=$(Z)\
-	TARGET=riscv TARGET-ARCH=riscv32-elf ADDITIONAL_ARCH_FLAGS="--with-arch=rv32ifd" all;\
-	cd $(TOOLS); $(MAKE) PATH=$(Z)\
-	TARGET=arm TARGET-ARCH=arm-none-eabi ADDITIONAL_ARCH_FLAGS="--with-cpu=cortex-m4 --with-fpu=fpv4-sp-d16 --with-mode=thumb --with-float=hard" all;\
+# cross-msp430:
 #	cd $(TOOLS); $(MAKE) PATH=$(Z)\
 #	TARGET=msp430 TARGET-ARCH=msp430 all;\
+
+cross-all: cross-arm cross-superH cross-riscv
 
 clean:
 	cd $(TOOLS); $(MAKE) nuke; \

--- a/conf/setup.conf
+++ b/conf/setup.conf
@@ -39,6 +39,7 @@ TOOLCXX		= g++
 ##
 GCCINCLUDEDIR   = $(SUNFLOWERROOT)/tools/source/gcc-8.2.0/gcc/ginclude/
 TOOLS		= $(SUNFLOWERROOT)/tools
+TOOLCHAIN	= $(SUNFLOWERROOT)/sunflower-toolchain
 PREFIX		= $(TOOLS)/$(TARGET)
 TOOLSBIN	= $(TOOLS)/bin
 TOOLSLIB	= $(SUNFLOWERROOT)/tools/tools-lib


### PR DESCRIPTION
Added alias for toolchain. cross-all is now dependent on cross-xxx.
This PR is paired with the `Removed Makefile duplication` PR for the sunflower-simulator repository to address issue #20 